### PR TITLE
[reporting] decouple os.Stdout from PrintReport

### DIFF
--- a/cmd/jsonreporter.go
+++ b/cmd/jsonreporter.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"encoding/json"
+	"io"
 	"math"
-	"os"
 	"time"
 
 	"github.com/HdrHistogram/hdrhistogram-go"
@@ -43,7 +43,7 @@ type jsonResult struct {
 	LatencyDistribution      []histogramPoint `json:"latencyDistribution,omitempty"`
 }
 
-func (s *jsonReporter) print(b *Benchmark, timings *hdrhistogram.Histogram, codeTotals map[int]int64, totalCounters Counters, qtypeTotals map[string]int64, topErrs orderedMap, t time.Duration) error {
+func (s *jsonReporter) print(w io.Writer, b *Benchmark, timings *hdrhistogram.Histogram, codeTotals map[int]int64, totalCounters Counters, qtypeTotals map[string]int64, topErrs orderedMap, t time.Duration) error {
 	sumerrs := int64(0)
 	for _, v := range topErrs.m {
 		sumerrs += int64(v)
@@ -108,5 +108,5 @@ func (s *jsonReporter) print(b *Benchmark, timings *hdrhistogram.Histogram, code
 		LatencyDistribution: res,
 	}
 
-	return json.NewEncoder(os.Stdout).Encode(result)
+	return json.NewEncoder(w).Encode(result)
 }

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"sort"
 	"time"
@@ -22,7 +23,7 @@ type orderedMap struct {
 }
 
 // PrintReport print formatted benchmark results to stdout. If there is a fatal error while printing report, an error is returned.
-func (b *Benchmark) PrintReport(stats []*ResultStats, t time.Duration) error {
+func (b *Benchmark) PrintReport(w io.Writer, stats []*ResultStats, t time.Duration) error {
 	// merge all the stats here
 	timings := hdrhistogram.New(b.HistMin.Nanoseconds(), b.HistMax.Nanoseconds(), b.HistPre)
 	codeTotals := make(map[int]int64)
@@ -126,10 +127,10 @@ func (b *Benchmark) PrintReport(stats []*ResultStats, t time.Duration) error {
 	topErrs := orderedMap{m: top3errs, order: top3errorsInOrder}
 	if b.JSON {
 		j := jsonReporter{}
-		return j.print(b, timings, codeTotals, totalCounters, qtypeTotals, topErrs, t)
+		return j.print(w, b, timings, codeTotals, totalCounters, qtypeTotals, topErrs, t)
 	}
 	s := standardReporter{}
-	return s.print(b, timings, codeTotals, totalCounters, qtypeTotals, topErrs, t)
+	return s.print(w, b, timings, codeTotals, totalCounters, qtypeTotals, topErrs, t)
 }
 
 func (b *Benchmark) fileName(dir, name string) string {

--- a/cmd/report_test.go
+++ b/cmd/report_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"os"
 	"time"
 
 	"github.com/HdrHistogram/hdrhistogram-go"
@@ -11,7 +12,7 @@ import (
 func Example_standard_printReport() {
 	b, rs := testData()
 
-	b.PrintReport([]*ResultStats{&rs}, time.Second)
+	b.PrintReport(os.Stdout, []*ResultStats{&rs}, time.Second)
 
 	// Output: Total requests:		1
 	// Read/Write errors:	3
@@ -50,7 +51,7 @@ func Example_json_printReport() {
 	b.Rcodes = true
 	b.HistDisplay = true
 
-	b.PrintReport([]*ResultStats{&rs}, time.Second)
+	b.PrintReport(os.Stdout, []*ResultStats{&rs}, time.Second)
 
 	// Output: {"totalRequests":1,"totalSuccessCodes":4,"totalErrors":3,"TotalIDmismatch":6,"totalTruncatedResponses":7,"responseRcodes":{"NOERROR":2},"questionTypes":{"A":2},"queriesPerSecond":1,"benchmarkDurationSeconds":1,"latencyStats":{"minMs":0,"meanMs":0,"stdMs":0,"maxMs":0,"p99Ms":0,"p95Ms":0,"p90Ms":0,"p75Ms":0,"p50Ms":0},"latencyDistribution":[{"latencyMs":0,"count":0},{"latencyMs":0,"count":0},{"latencyMs":0,"count":0},{"latencyMs":0,"count":0},{"latencyMs":0,"count":0},{"latencyMs":0,"count":1},{"latencyMs":0,"count":0},{"latencyMs":0,"count":0},{"latencyMs":0,"count":0},{"latencyMs":0,"count":0},{"latencyMs":0,"count":1}]}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -152,7 +152,7 @@ func Execute() {
 	if err != nil {
 		errPrint(os.Stderr, "There was an error while starting benchmark: %s\n", err.Error())
 	} else {
-		if err := benchmark.PrintReport(res, end.Sub(start)); err != nil {
+		if err := benchmark.PrintReport(os.Stdout, res, end.Sub(start)); err != nil {
 			errPrint(os.Stderr, "There was an error while printing report: %s\n", err.Error())
 		}
 	}


### PR DESCRIPTION
This enables calling dnspyre from other binaries/tools without worrying about os.Args and
os.Stdout.

Signed-off-by: Raul Gutierrez Segales <rsegales@nvidia.com>