### PR TITLE
do not pre resolve server hostnames to mitigate cert validation errors

### DIFF
--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -199,18 +199,6 @@ func (b *Benchmark) prepare() error {
 
 	b.addPortIfMissing()
 
-	if !b.useDoH && !b.useQuic {
-		host, port, err := net.SplitHostPort(b.Server)
-		if err != nil {
-			return errors.New("failed to parse --server")
-		}
-		addr, err := net.ResolveIPAddr("ip", host)
-		if err != nil {
-			return errors.New("failed to resolve --server address")
-		}
-		b.Server = net.JoinHostPort(addr.String(), port)
-	}
-
 	if b.Count == 0 && b.Duration == 0 {
 		b.Count = 1
 	}

--- a/cmd/benchmark_test.go
+++ b/cmd/benchmark_test.go
@@ -639,21 +639,6 @@ func TestBenchmark_prepare(t *testing.T) {
 			wantServer: "[fddd:dddd::]:53",
 		},
 		{
-			name:       "server - resolve addr for plain DNS",
-			benchmark:  Benchmark{Server: "google-public-dns-a.google.com"},
-			wantServer: "8.8.8.8:53",
-		},
-		{
-			name:       "server - resolve addr with port for plain DNS",
-			benchmark:  Benchmark{Server: "google-public-dns-a.google.com:53"},
-			wantServer: "8.8.8.8:53",
-		},
-		{
-			name:       "server - resolve addr for DoT",
-			benchmark:  Benchmark{Server: "google-public-dns-a.google.com", DOT: true},
-			wantServer: "8.8.8.8:853",
-		},
-		{
 			name:       "server - DoT with IP address",
 			benchmark:  Benchmark{Server: "8.8.8.8", DOT: true},
 			wantServer: "8.8.8.8:853",


### PR DESCRIPTION
related to https://github.com/Tantalor93/dnspyre/issues/208, the issue was introduced by https://github.com/Tantalor93/dnspyre/pull/190 by pre-resolving plain DNS and DoT server names there are eventually issues with servers with TLS certs not binding the IP name in cert

the actual functionality of resolving plain DNS and DoT server names is provided by miek/dns internally, no need to do it ourselves