### PR TITLE
fix(manpages): remove redundant run and gzip output

### DIFF
--- a/scripts/manpages.sh
+++ b/scripts/manpages.sh
@@ -3,6 +3,5 @@
 set -e
 rm -rf manpages
 mkdir manpages
-for sh in bash zsh; do
-	go run main.go --help-man >"manpages/dnspyre.1"
-done
+go run main.go --help-man >"manpages/dnspyre.1"
+gzip --best "manpages/dnspyre.1"


### PR DESCRIPTION
The redundancy appears to be a copy-paste error by duplicating the `scripts/completions.sh` script.

And it is conventional to store manpages in a compressed (gzip) format. This change compresses in-place (`manpages/dnspyre.1.gz`). If you would prefer it retain the uncompressed copy for some reason, add flag `--keep`.